### PR TITLE
Implement validation, refresh tokens and search

### DIFF
--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -5,39 +5,56 @@ use App\Core\Request;
 use App\Core\Response;
 use App\Core\Auth as JWTAuth;
 use App\Models\User;
+use App\Core\Validator;
 
 class AuthController
 {
     public function register(Request $req, Response $res): void
     {
-        $name = trim($req->body['name'] ?? '');
-        $email = strtolower(trim($req->body['email'] ?? ''));
-        $password = $req->body['password'] ?? '';
-        if (!$name || !filter_var($email, FILTER_VALIDATE_EMAIL) || strlen($password) < 6) {
-            $res->json(['error'=>'Invalid input'],422);
-            return;
-        }
-        if (User::findByEmail($email)) {
-            $res->json(['error'=>'Email already in use'],409);
-            return;
-        }
-        $hash = password_hash($password, PASSWORD_BCRYPT);
-        $id = User::create($name,$email,$hash);
+        $data = $req->getParsedBody();
+        $errors = Validator::validate($data,[
+            'name'=>'required',
+            'email'=>'required|email',
+            'password'=>'required|min:6'
+        ]);
+        if ($errors) { $res->json(['error'=>'Invalid input','details'=>$errors],422); return; }
+        $email = strtolower($data['email']);
+        if (User::findByEmail($email)) { $res->json(['error'=>'Email already in use'],409); return; }
+        $hash = password_hash($data['password'], PASSWORD_BCRYPT);
+        $id = User::create($data['name'],$email,$hash);
         $res->json(['message'=>'Registered','user_id'=>$id],201);
     }
 
     public function login(Request $req, Response $res): void
     {
-        $email = strtolower(trim($req->body['email'] ?? ''));
-        $password = $req->body['password'] ?? '';
+        $data = $req->getParsedBody();
+        $email = strtolower(trim($data['email'] ?? ''));
+        $password = $data['password'] ?? '';
         $user = $email ? User::findByEmail($email) : null;
         if (!$user || !password_verify($password, $user['password_hash'])) {
-            $res->json(['error'=>'Invalid credentials'],401);
-            return;
+            $res->json(['error'=>'Invalid credentials'],401); return;
         }
         $token = JWTAuth::issue(['uid'=>$user['id'],'role'=>$user['role']]);
-        $res->json(['access_token'=>$token,'user'=>[
+        $refresh = bin2hex(random_bytes(32));
+        User::saveRefreshToken($user['id'],$refresh);
+        $res->json(['access_token'=>$token,'refresh_token'=>$refresh,'user'=>[
             'id'=>$user['id'], 'name'=>$user['name'], 'email'=>$user['email'], 'role'=>$user['role']
         ]]);
+    }
+
+    public function refresh(Request $req, Response $res): void
+    {
+        $data = $req->getParsedBody();
+        $token = $data['refresh_token'] ?? '';
+        if (!$token) { $res->json(['error'=>'Invalid token'],401); return; }
+        $user = User::findByRefreshToken($token);
+        if (!$user) { $res->json(['error'=>'Invalid token'],401); return; }
+        $access = JWTAuth::issue(['uid'=>$user['id'],'role'=>$user['role']]);
+        $res->json(['access_token'=>$access]);
+    }
+
+    public function users(Request $req, Response $res): void
+    {
+        $res->json(['data'=>User::all()]);
     }
 }

--- a/app/Controllers/CafeController.php
+++ b/app/Controllers/CafeController.php
@@ -9,16 +9,28 @@ class CafeController
 {
     public function index(Request $req, Response $res): void
     {
-        $page = max(1, (int)($req->query['page'] ?? 1));
-        $per = min(50, max(1, (int)($req->query['per_page'] ?? 10)));
-        $category = isset($req->query['category_id']) ? (int)$req->query['category_id'] : null;
+        $query = $req->getQueryParams();
+        $page = max(1, (int)($query['page'] ?? 1));
+        $per = min(50, max(1, (int)($query['per_page'] ?? 10)));
+        $category = isset($query['category_id']) ? (int)$query['category_id'] : null;
         $data = Cafe::paginate($page,$per,$category);
+        $res->json(['data'=>$data]);
+    }
+
+    public function search(Request $req, Response $res): void
+    {
+        $query = $req->getQueryParams();
+        $term = trim($query['q'] ?? '');
+        if ($term === '') { $res->json(['error'=>'Missing query'],422); return; }
+        $page = max(1, (int)($query['page'] ?? 1));
+        $per = min(50, max(1, (int)($query['per_page'] ?? 10)));
+        $data = Cafe::search($term,$page,$per);
         $res->json(['data'=>$data]);
     }
 
     public function show(Request $req, Response $res): void
     {
-        $id = (int)$req->params['id'];
+        $id = (int)$req->getAttribute('id');
         $cafe = Cafe::find($id);
         if (!$cafe) { $res->json(['error'=>'Not found'],404); return; }
         $res->json(['data'=>$cafe]);

--- a/app/Controllers/ReviewController.php
+++ b/app/Controllers/ReviewController.php
@@ -9,19 +9,22 @@ class ReviewController
 {
     public function list(Request $req, Response $res): void
     {
-        $cafeId = (int)$req->params['id'];
-        $page = max(1, (int)($req->query['page'] ?? 1));
-        $per = min(50, max(1, (int)($req->query['per_page'] ?? 10)));
+        $cafeId = (int)$req->getAttribute('id');
+        $query = $req->getQueryParams();
+        $page = max(1, (int)($query['page'] ?? 1));
+        $per = min(50, max(1, (int)($query['per_page'] ?? 10)));
         $data = Review::listByCafe($cafeId,$page,$per);
         $res->json(['data'=>$data]);
     }
 
     public function create(Request $req, Response $res): void
     {
-        $cafeId = (int)$req->params['id'];
-        $rating = (int)($req->body['rating'] ?? 0);
-        $content = trim($req->body['content'] ?? '');
-        $userId = (int)($req->user['uid'] ?? 0);
+        $cafeId = (int)$req->getAttribute('id');
+        $body = $req->getParsedBody();
+        $rating = (int)($body['rating'] ?? 0);
+        $content = trim($body['content'] ?? '');
+        $user = $req->getAttribute('user', []);
+        $userId = (int)($user['uid'] ?? 0);
         if ($rating < 1 || $rating > 5 || !$content) {
             $res->json(['error'=>'Invalid input'],422);
             return;

--- a/app/Core/Middleware.php
+++ b/app/Core/Middleware.php
@@ -1,9 +1,7 @@
 <?php
 namespace App\Core;
 
-use App\Core\Request;
-
 interface Middleware
 {
-    public function handle(Request $request = null): void;
+    public function handle(Request $request): Request;
 }

--- a/app/Core/Request.php
+++ b/app/Core/Request.php
@@ -8,8 +8,7 @@ class Request
     public array $headers;
     public array $query;
     public array $body;
-    public array $params = [];
-    public array $user = [];
+    private array $attributes = [];
 
     public static function capture(): self
     {
@@ -22,4 +21,13 @@ class Request
         $req->body = json_decode($raw, true) ?: [];
         return $req;
     }
+
+    // PSR-7 like helpers
+    public function getMethod(): string { return $this->method; }
+    public function getUri(): string { return $this->uri; }
+    public function getHeaderLine(string $name): string { return $this->headers[$name] ?? ''; }
+    public function getQueryParams(): array { return $this->query; }
+    public function getParsedBody(): array { return $this->body; }
+    public function withAttribute(string $key, $value): self { $clone = clone $this; $clone->attributes[$key] = $value; return $clone; }
+    public function getAttribute(string $key, $default=null) { return $this->attributes[$key] ?? $default; }
 }

--- a/app/Core/Validator.php
+++ b/app/Core/Validator.php
@@ -1,0 +1,29 @@
+<?php
+namespace App\Core;
+
+class Validator
+{
+    public static function validate(array $data, array $rules): array
+    {
+        $errors = [];
+        foreach ($rules as $field => $ruleStr) {
+            $rulesArr = explode('|', $ruleStr);
+            $value = trim((string)($data[$field] ?? ''));
+            foreach ($rulesArr as $rule) {
+                if ($rule === 'required' && $value === '') {
+                    $errors[$field] = 'required';
+                    break;
+                }
+                if ($rule === 'email' && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
+                    $errors[$field] = 'email';
+                    break;
+                }
+                if (str_starts_with($rule, 'min:')) {
+                    $min = (int)substr($rule,4);
+                    if (strlen($value) < $min) { $errors[$field] = 'min'; break; }
+                }
+            }
+        }
+        return $errors;
+    }
+}

--- a/app/Middlewares/AdminMiddleware.php
+++ b/app/Middlewares/AdminMiddleware.php
@@ -1,0 +1,19 @@
+<?php
+namespace App\Middlewares;
+
+use App\Core\Middleware;
+use App\Core\Request;
+
+class AdminMiddleware implements Middleware
+{
+    public function handle(Request $request): Request
+    {
+        $user = $request->getAttribute('user', []);
+        if (($user['role'] ?? '') !== 'admin') {
+            http_response_code(403);
+            echo json_encode(['error'=>'Forbidden']);
+            exit;
+        }
+        return $request;
+    }
+}

--- a/app/Middlewares/AuthMiddleware.php
+++ b/app/Middlewares/AuthMiddleware.php
@@ -4,12 +4,13 @@ namespace App\Middlewares;
 use App\Core\Middleware;
 use App\Core\Request;
 use App\Core\Auth as JWTAuth;
+use Firebase\JWT\ExpiredException;
 
 class AuthMiddleware implements Middleware
 {
-    public function handle(Request $request = null): void
+    public function handle(Request $request): Request
     {
-        $hdr = $request->headers['Authorization'] ?? '';
+        $hdr = $request->getHeaderLine('Authorization');
         if (!preg_match('#^Bearer\s+(.*)$#i', $hdr, $m)) {
             http_response_code(401);
             echo json_encode(['error'=>'Missing token']);
@@ -17,8 +18,14 @@ class AuthMiddleware implements Middleware
         }
         try {
             $claims = JWTAuth::verify($m[1]);
-            $request->user = $claims;
+            return $request->withAttribute('user',$claims);
+        } catch (ExpiredException $e) {
+            error_log($e->getMessage());
+            http_response_code(401);
+            echo json_encode(['error'=>'Token expired']);
+            exit;
         } catch (\Throwable $e) {
+            error_log($e->getMessage());
             http_response_code(401);
             echo json_encode(['error'=>'Invalid token']);
             exit;

--- a/app/Middlewares/CorsMiddleware.php
+++ b/app/Middlewares/CorsMiddleware.php
@@ -2,13 +2,15 @@
 namespace App\Middlewares;
 
 use App\Core\Middleware;
+use App\Core\Request;
 
 class CorsMiddleware implements Middleware
 {
-    public function handle($request = null): void
+    public function handle(Request $request): Request
     {
         header('Access-Control-Allow-Origin: *');
         header('Access-Control-Allow-Methods: GET, POST, PATCH, DELETE, OPTIONS');
         header('Access-Control-Allow-Headers: Content-Type, Authorization');
+        return $request;
     }
 }

--- a/app/Models/Cafe.php
+++ b/app/Models/Cafe.php
@@ -29,6 +29,22 @@ class Cafe
         return ['items'=>$items,'total'=>$count,'page'=>$page,'per_page'=>$per];
     }
 
+    public static function search(string $term, int $page=1, int $per=10): array
+    {
+        $offset = ($page-1)*$per;
+        $stmt = DB::pdo()->prepare('SELECT * FROM cafes WHERE name LIKE ? ORDER BY id DESC LIMIT ? OFFSET ?');
+        $like = '%'.$term.'%';
+        $stmt->bindValue(1,$like,\PDO::PARAM_STR);
+        $stmt->bindValue(2,$per,\PDO::PARAM_INT);
+        $stmt->bindValue(3,$offset,\PDO::PARAM_INT);
+        $stmt->execute();
+        $items = $stmt->fetchAll();
+        $countStmt = DB::pdo()->prepare('SELECT COUNT(*) FROM cafes WHERE name LIKE ?');
+        $countStmt->execute([$like]);
+        $count = (int)$countStmt->fetchColumn();
+        return ['items'=>$items,'total'=>$count,'page'=>$page,'per_page'=>$per];
+    }
+
     public static function find(int $id): ?array
     {
         $stmt = DB::pdo()->prepare('SELECT * FROM cafes WHERE id=?');

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,4 +19,24 @@ class User
         $stmt->execute([$name,$email,$passwordHash,$role]);
         return (int)DB::pdo()->lastInsertId();
     }
+
+    public static function saveRefreshToken(int $id, string $token): void
+    {
+        $stmt = DB::pdo()->prepare('UPDATE users SET refresh_token=? WHERE id=?');
+        $stmt->execute([$token,$id]);
+    }
+
+    public static function findByRefreshToken(string $token): ?array
+    {
+        $stmt = DB::pdo()->prepare('SELECT * FROM users WHERE refresh_token=? LIMIT 1');
+        $stmt->execute([$token]);
+        $row = $stmt->fetch();
+        return $row ?: null;
+    }
+
+    public static function all(): array
+    {
+        $stmt = DB::pdo()->query('SELECT id,name,email,role FROM users');
+        return $stmt->fetchAll();
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,15 @@
     "vlucas/phpdotenv": "^5.6",
     "firebase/php-jwt": "^6.10"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^10.5"
+  },
   "autoload": {
     "psr-4": {
       "App\\": "app/"
     }
+  },
+  "scripts": {
+    "test": "vendor/bin/phpunit"
   }
 }

--- a/database/migrations/2025_08_18_000000_init.sql
+++ b/database/migrations/2025_08_18_000000_init.sql
@@ -8,7 +8,8 @@ CREATE TABLE users (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
     email VARCHAR(150) NOT NULL UNIQUE,
-    password VARCHAR(255) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    refresh_token VARCHAR(255) NULL,
     role ENUM('admin','customer','owner') DEFAULT 'customer',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP

--- a/database/seeders/seed.php
+++ b/database/seeders/seed.php
@@ -29,7 +29,7 @@ $users = [
     ['Carol','carol@example.com','password123','owner']
 ];
 foreach ($users as $u) {
-    $pdo->prepare("INSERT IGNORE INTO users(name,email,password,role) VALUES(?,?,?,?)")
+    $pdo->prepare("INSERT IGNORE INTO users(name,email,password_hash,role) VALUES(?,?,?,?)")
         ->execute([$u[0], $u[1], password_hash($u[2], PASSWORD_BCRYPT), $u[3]]);
 }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="App Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="JWT_SECRET" value="test"/>
+  </php>
+</phpunit>

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,14 +4,18 @@ use App\Controllers\AuthController;
 use App\Controllers\CafeController;
 use App\Controllers\ReviewController;
 use App\Middlewares\AuthMiddleware;
+use App\Middlewares\AdminMiddleware;
 
 /** @var Router $router */
 $router = $app['router'];
 
 $router->add('POST','/api/auth/register',[AuthController::class,'register']);
 $router->add('POST','/api/auth/login',[AuthController::class,'login']);
+$router->add('POST','/api/auth/refresh',[AuthController::class,'refresh']);
+$router->add('GET','/api/users',[AuthController::class,'users'],[AuthMiddleware::class,AdminMiddleware::class]);
 
 $router->add('GET','/api/cafes',[CafeController::class,'index']);
+$router->add('GET','/api/cafes/search',[CafeController::class,'search']);
 $router->add('GET','/api/cafes/{id}',[CafeController::class,'show']);
 
 $router->add('GET','/api/cafes/{id}/reviews',[ReviewController::class,'list']);

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -1,0 +1,22 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use App\Core\Auth;
+
+final class AuthTest extends TestCase
+{
+    public function testIssueAndVerify(): void
+    {
+        $_ENV['JWT_SECRET'] = 'test';
+        $token = Auth::issue(['uid'=>1], 3600);
+        $claims = Auth::verify($token);
+        $this->assertSame(1, $claims['uid']);
+    }
+
+    public function testExpiredToken(): void
+    {
+        $_ENV['JWT_SECRET'] = 'test';
+        $token = Auth::issue(['uid'=>1], -1);
+        $this->expectException(Firebase\JWT\ExpiredException::class);
+        Auth::verify($token);
+    }
+}

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1,0 +1,12 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use App\Core\Validator;
+
+final class ValidatorTest extends TestCase
+{
+    public function testInvalidEmail(): void
+    {
+        $errors = Validator::validate(['email'=>'bad'],['email'=>'required|email']);
+        $this->assertArrayHasKey('email',$errors);
+    }
+}


### PR DESCRIPTION
## Summary
- Align users table schema with `password_hash` and `refresh_token`
- Add refresh-token based auth flow, admin-protected user listing, and PSR-like request helpers
- Introduce basic validator, cafe search endpoint, and unit tests

## Testing
- `php -l app/Core/Request.php app/Core/Middleware.php app/Middlewares/CorsMiddleware.php app/Middlewares/AuthMiddleware.php app/Middlewares/AdminMiddleware.php app/Core/Router.php app/Core/Validator.php app/Controllers/AuthController.php app/Controllers/CafeController.php app/Controllers/ReviewController.php app/Models/Cafe.php app/Models/User.php routes/api.php database/migrations/2025_08_18_000000_init.sql database/seeders/seed.php tests/AuthTest.php tests/ValidatorTest.php`
- `composer test` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3eeeb45388322ba91d375b38b377a