### PR TITLE
Add role-based authorization middleware and validation

### DIFF
--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -12,16 +12,18 @@ class AuthController
     public function register(Request $req, Response $res): void
     {
         $data = $req->getParsedBody();
+        $data['role'] = $data['role'] ?? 'customer';
         $errors = Validator::validate($data,[
             'name'=>'required',
             'email'=>'required|email',
-            'password'=>'required|min:6'
+            'password'=>'required|min:6',
+            'role'=>'in:admin,shop,customer'
         ]);
         if ($errors) { $res->json(['error'=>'Invalid input','details'=>$errors],422); return; }
         $email = strtolower($data['email']);
         if (User::findByEmail($email)) { $res->json(['error'=>'Email already in use'],409); return; }
         $hash = password_hash($data['password'], PASSWORD_BCRYPT);
-        $id = User::create($data['name'],$email,$hash);
+        $id = User::create($data['name'],$email,$hash,$data['role']);
         $res->json(['message'=>'Registered','user_id'=>$id],201);
     }
 

--- a/app/Core/Validator.php
+++ b/app/Core/Validator.php
@@ -22,6 +22,10 @@ class Validator
                     $min = (int)substr($rule,4);
                     if (strlen($value) < $min) { $errors[$field] = 'min'; break; }
                 }
+                if (str_starts_with($rule, 'in:')) {
+                    $allowed = explode(',', substr($rule, 3));
+                    if (!in_array($value, $allowed, true)) { $errors[$field] = 'in'; break; }
+                }
             }
         }
         return $errors;

--- a/app/Middlewares/RoleMiddleware.php
+++ b/app/Middlewares/RoleMiddleware.php
@@ -1,0 +1,26 @@
+<?php
+namespace App\Middlewares;
+
+use App\Core\Middleware;
+use App\Core\Request;
+
+abstract class RoleMiddleware implements Middleware
+{
+    /**
+     * Return allowed roles for the middleware.
+     *
+     * @return string[]
+     */
+    abstract protected function roles(): array;
+
+    public function handle(Request $request): Request
+    {
+        $user = $request->getAttribute('user', []);
+        if (!in_array($user['role'] ?? '', $this->roles(), true)) {
+            http_response_code(403);
+            echo json_encode(['error' => 'Forbidden']);
+            exit;
+        }
+        return $request;
+    }
+}

--- a/app/Middlewares/ShopMiddleware.php
+++ b/app/Middlewares/ShopMiddleware.php
@@ -1,10 +1,10 @@
 <?php
 namespace App\Middlewares;
 
-class AdminMiddleware extends RoleMiddleware
+class ShopMiddleware extends RoleMiddleware
 {
     protected function roles(): array
     {
-        return ['admin'];
+        return ['shop'];
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -9,4 +9,10 @@ final class ValidatorTest extends TestCase
         $errors = Validator::validate(['email'=>'bad'],['email'=>'required|email']);
         $this->assertArrayHasKey('email',$errors);
     }
+
+    public function testInRule(): void
+    {
+        $errors = Validator::validate(['role'=>'guest'],['role'=>'in:admin,shop,customer']);
+        $this->assertArrayHasKey('role',$errors);
+    }
 }


### PR DESCRIPTION
## Summary
- Add reusable `RoleMiddleware` with dedicated `AdminMiddleware` and `ShopMiddleware`
- Allow specifying user roles during registration with validation
- Extend validator with `in:` rule and cover it in tests

## Testing
- `php -l app/Middlewares/RoleMiddleware.php app/Middlewares/ShopMiddleware.php app/Middlewares/AdminMiddleware.php app/Controllers/AuthController.php app/Core/Validator.php tests/ValidatorTest.php`
- `composer test` *(fails: vendor/bin/phpunit not found)*
- `composer update phpunit/phpunit` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4082350c4832283f4994c3e06cec4