### PR TITLE
Remove stray markers from seeder user loop

### DIFF
--- a/database/seeders/seed.php
+++ b/database/seeders/seed.php
@@ -31,13 +31,11 @@ $users = [
     ['alice','alice@example.com','secret123','Alice','user','0987654321']
 ];
 foreach ($users as $u) {
-codex/anh-gia-du-an-kjabc3
     $pdo->prepare("INSERT INTO nguoi_dung(ten_dang_nhap,email,mat_khau_ma_hoa,ho_va_ten,vai_tro,so_dien_thoai) VALUES (?,?,?,?,?,?)")
         ->execute([$u[0],$u[1],password_hash($u[2],PASSWORD_BCRYPT),$u[3],$u[4],$u[5]]);
 
     $pdo->prepare("INSERT IGNORE INTO users(name,email,password_hash,role) VALUES(?,?,?,?)")
         ->execute([$u[0], $u[1], password_hash($u[2], PASSWORD_BCRYPT), $u[3]]);
-main
 }
 
 // Location


### PR DESCRIPTION
## Summary
- clean user seeding loop in `seed.php` by removing stray text markers

## Testing
- `composer test`