### PR TITLE
Harden security and correct documentation

### DIFF
--- a/.env
+++ b/.env
@@ -9,3 +9,4 @@ DB_USERNAME=root
 DB_PASSWORD=
 
 JWT_SECRET=batky_chuoi_bimat
+CORS_ALLOWED_ORIGIN=http://localhost

--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@ DB_USERNAME=root
 DB_PASSWORD=your-password
 
 JWT_SECRET=supersecret_change_me
+CORS_ALLOWED_ORIGIN=http://localhost

--- a/README.md
+++ b/README.md
@@ -6,14 +6,12 @@ This repository provides the lightweight PHP MVC backend that powers its RESTful
 - `POST /api/auth/register`
 - `POST /api/auth/login` → returns `{access_token, user}`
 - `POST /api/auth/refresh`
-- `POST /api/auth/logout`
-- `GET /api/auth/me`
+- `GET /api/users` (admin only)
 - `GET /api/cafes?per_page=10&page=1`
+- `GET /api/cafes/search?q=term`
 - `GET /api/cafes/{id}`
+- `GET /api/cafes/{id}/reviews`
 - `POST /api/cafes/{id}/reviews`
-- `GET /api/users/{id}`
-- `PATCH /api/users/{id}`
-- `GET /api/categories`
 
 More endpoints are available in `routes/api.php`.
 
@@ -34,7 +32,7 @@ $router->get('/admin/users', 'AdminController@index')
 
 
 ## Features
-- JWT authentication with register, login, refresh and logout flows
+- JWT authentication with register, login and refresh flows
 - User profiles with favorites
 - Café CRUD with media uploads and filtering by category, rating, city and distance
 - Review creation and moderation

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -12,18 +12,16 @@ class AuthController
     public function register(Request $req, Response $res): void
     {
         $data = $req->getParsedBody();
-        $data['vai_tro'] = $data['vai_tro'] ?? 'user';
         $errors = Validator::validate($data,[
             'ten_dang_nhap'=>'required',
             'email'=>'required|email',
-            'password'=>'required|min:6',
-            'vai_tro'=>'in:admin,shop,user'
+            'password'=>'required|min:6'
         ]);
         if ($errors) { $res->json(['error'=>'Invalid input','details'=>$errors],422); return; }
         $email = strtolower($data['email']);
         if (User::findByEmail($email)) { $res->json(['error'=>'Email already in use'],409); return; }
         $hash = password_hash($data['password'], PASSWORD_BCRYPT);
-        $id = User::create($data['ten_dang_nhap'],$email,$hash,$data['vai_tro']);
+        $id = User::create($data['ten_dang_nhap'],$email,$hash,'user');
         $res->json(['message'=>'Registered','user_id'=>$id],201);
     }
 

--- a/app/Core/DB.php
+++ b/app/Core/DB.php
@@ -18,30 +18,13 @@ class DB
         $pass   = $cfg['password'] ?? '';
         $charset = 'utf8mb4';
 
+        $dsn = sprintf('%s:host=%s;port=%d;dbname=%s;charset=%s', $driver, $host, $port, $db, $charset);
         try {
-            $dsn = sprintf('%s:host=%s;port=%d;dbname=%s;charset=%s', $driver, $host, $port, $db, $charset);
             self::$pdo = new PDO($dsn, $user, $pass, [
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                 PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
             ]);
-            return;
         } catch (PDOException $e) {
-            if (str_contains($e->getMessage(), 'Unknown database')) {
-                $dsnNoDb = sprintf('%s:host=%s;port=%d;charset=%s', $driver, $host, $port, $charset);
-                $tmp = new PDO($dsnNoDb, $user, $pass, [
-                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-                ]);
-                $tmp->exec("CREATE DATABASE IF NOT EXISTS `$db` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;");
-                $tmp = null;
-
-                $dsn = sprintf('%s:host=%s;port=%d;dbname=%s;charset=%s', $driver, $host, $port, $db, $charset);
-                self::$pdo = new PDO($dsn, $user, $pass, [
-                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-                ]);
-                return;
-            }
             throw $e;
         }
     }

--- a/app/Middlewares/CorsMiddleware.php
+++ b/app/Middlewares/CorsMiddleware.php
@@ -8,7 +8,10 @@ class CorsMiddleware implements Middleware
 {
     public function handle(Request $request): Request
     {
-        header('Access-Control-Allow-Origin: *');
+        $origin = $_ENV['CORS_ALLOWED_ORIGIN'] ?? '';
+        if ($origin !== '') {
+            header('Access-Control-Allow-Origin: ' . $origin);
+        }
         header('Access-Control-Allow-Methods: GET, POST, PATCH, DELETE, OPTIONS');
         header('Access-Control-Allow-Headers: Content-Type, Authorization');
         return $request;

--- a/app/Models/Cafe.php
+++ b/app/Models/Cafe.php
@@ -18,14 +18,18 @@ class Cafe
             $stmt->bindValue(2,$per,\PDO::PARAM_INT);
             $stmt->bindValue(3,$offset,\PDO::PARAM_INT);
             $stmt->execute();
+            $items = $stmt->fetchAll();
+            $countStmt = DB::pdo()->prepare('SELECT COUNT(*) FROM cua_hang c JOIN cua_hang_chuyen_muc cc ON cc.id_cua_hang=c.id_cua_hang WHERE cc.id_chuyen_muc=?');
+            $countStmt->execute([$categoryId]);
+            $count = (int)$countStmt->fetchColumn();
         } else {
             $stmt = DB::pdo()->prepare('SELECT * FROM cua_hang ORDER BY id_cua_hang DESC LIMIT ? OFFSET ?');
             $stmt->bindValue(1,$per,\PDO::PARAM_INT);
             $stmt->bindValue(2,$offset,\PDO::PARAM_INT);
             $stmt->execute();
+            $items = $stmt->fetchAll();
+            $count = (int)DB::pdo()->query('SELECT COUNT(*) FROM cua_hang')->fetchColumn();
         }
-        $items = $stmt->fetchAll();
-        $count = (int)DB::pdo()->query('SELECT COUNT(*) FROM cua_hang')->fetchColumn();
         return ['items'=>$items,'total'=>$count,'page'=>$page,'per_page'=>$per];
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -22,14 +22,16 @@ class User
 
     public static function saveRefreshToken(int $id_user, string $token): void
     {
+        $hash = hash('sha256', $token);
         $stmt = DB::pdo()->prepare('UPDATE users SET refresh_token=? WHERE id_user=?');
-        $stmt->execute([$token,$id_user]);
+        $stmt->execute([$hash,$id_user]);
     }
 
     public static function findByRefreshToken(string $token): ?array
     {
+        $hash = hash('sha256', $token);
         $stmt = DB::pdo()->prepare('SELECT * FROM users WHERE refresh_token=? LIMIT 1');
-        $stmt->execute([$token]);
+        $stmt->execute([$hash]);
         $row = $stmt->fetch();
         return $row ?: null;
     }


### PR DESCRIPTION
## Summary
- Restrict registration to user role only and hash stored refresh tokens
- Remove automatic database creation and make CORS origin configurable
- Fix café pagination counts and update API documentation

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a57ae40c588322b79c25f470b6e467